### PR TITLE
switch task from part-of-speech to corrupted-part-of-speech

### DIFF
--- a/control_tasks/mdl_configs/bayes_l0_control.yml
+++ b/control_tasks/mdl_configs/bayes_l0_control.yml
@@ -34,7 +34,7 @@ regimen:
 probe:
   task_signature: word_label 
   type: bayes 
-  task_name: part-of-speech
+  task_name: corrupted-part-of-speech
   maximum_rank: 1000                # CHANGE THIS (IF YOU REALLY WANT)
   psd_parameters: True
   diagonal: False

--- a/control_tasks/mdl_configs/online_l0_control.yml
+++ b/control_tasks/mdl_configs/online_l0_control.yml
@@ -35,7 +35,7 @@ regimen:
 probe:
   task_signature: word_label 
   type: none # none
-  task_name: part-of-speech
+  task_name: corrupted-part-of-speech
   maximum_rank: 1000                # CHANGE THIS (IF YOU REALLY WANT)
   psd_parameters: True
   diagonal: False


### PR DESCRIPTION
The config files for the linguistic tasks (`online_l0.yml` and `bayes_l0.yml`), and those for the control tasks (`online_l0_control.yml` and `bayes_l0_control.yml`), all use `task_name: part-of-speech`. As I understand it, the control tasks work by setting `corrupted_token_percent: 1.0`, and the `PartOfSpeechLabelTask` doesn't handle corrupting tokens.

Without this change, I get the same results for both linguistic and control tasks, and those results match the linguistic task results in the paper. With this change, the control tasks match the control results in the paper.

Please let me know if this fix isn't correct as I'm using it for followup work!