### PR TITLE
Debugged the Online Code X Edge probing experiments

### DIFF
--- a/jiant/jiant/config/defaults.conf
+++ b/jiant/jiant/config/defaults.conf
@@ -464,7 +464,7 @@ nli-prob {
 
 // Template: Not used for any single task, but extended per-task below.
 edges-tmpl {
-    span_classifier_loss_fn = "sigmoid"  // 'sigmoid' or 'softmax'
+    span_classifier_loss_fn = "softmax"  // 'sigmoid' or 'softmax'
     classifier_span_pooling = "attn"  // 'attn' or 'x,y'
     classifier_hid_dim = 256
     classifier_dropout = 0.3

--- a/jiant/mdl_configs/pos_online_layer1.conf
+++ b/jiant/mdl_configs/pos_online_layer1.conf
@@ -27,6 +27,7 @@ write_preds = "val,test"
 
 lr_patience = 5  // vals until LR decay
 patience = 10      // vals until early-stopping
+min_epochs = 1 
 
 input_module = "elmo"
 tokenizer = MosesTokenizer


### PR DESCRIPTION
Add the parameter "min_epochs" to the online code config so that the program can run.
Set the default `span_classifier_loss_fn` of edge probing tasks to be 'softmax' in defaults.config so that the program will use a softmax layer + cross entropy loss. 